### PR TITLE
feat: add blob-backend & network modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Terraform local state
+*.tfstate*
+.terraform/
+
+# VSCode
+.vscode/

--- a/backend.tf.disabled
+++ b/backend.tf.disabled
@@ -1,0 +1,8 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name   = "cst8918-final-project-group-4"
+    storage_account_name  = "abou0344tfstate"
+    container_name        = "tfstate"
+    key                   = "terraform.tfstate"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,24 @@
+provider "azurerm" {
+  features {}
+}
+
+module "blob-backend" {
+  source               = "./modules/blob-backend"
+  resource_group_name  = "cst8918-final-project-group-4"
+  location             = "Canada Central"
+  storage_account_name = "abou0344tfstate"
+  container_name       = "tfstate"
+}
+
+module "network" {
+  source              = "./modules/network"
+  resource_group_name = "cst8918-final-project-group-4"
+  location            = "Canada Central"
+  vnet_cidr           = "10.0.0.0/14"
+  subnet_prefixes = {
+    prod  = "10.0.0.0/16"
+    test  = "10.1.0.0/16"
+    dev   = "10.2.0.0/16"
+    admin = "10.3.0.0/16"
+  }
+}

--- a/modules/blob-backend/main.tf
+++ b/modules/blob-backend/main.tf
@@ -1,0 +1,18 @@
+resource "azurerm_resource_group" "backend" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+resource "azurerm_storage_account" "backend" {
+  name                     = var.storage_account_name
+  resource_group_name      = azurerm_resource_group.backend.name
+  location                 = azurerm_resource_group.backend.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "backend" {
+  name                  = var.container_name
+  storage_account_name  = azurerm_storage_account.backend.name
+  container_access_type = "private"
+}

--- a/modules/blob-backend/outputs.tf
+++ b/modules/blob-backend/outputs.tf
@@ -1,0 +1,9 @@
+output "storage_account_id" {
+  value       = azurerm_storage_account.backend.id
+  description = "ID of the storage account"
+}
+
+output "container_name" {
+  value       = azurerm_storage_container.backend.name
+  description = "Name of the blob container"
+}

--- a/modules/blob-backend/variables.tf
+++ b/modules/blob-backend/variables.tf
@@ -1,0 +1,19 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the RG for the Terraform backend"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region to deploy the backend"
+}
+
+variable "storage_account_name" {
+  type        = string
+  description = "Name of the storage account for Terraform state"
+}
+
+variable "container_name" {
+  type        = string
+  description = "Blob container name for Terraform state"
+}

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,0 +1,14 @@
+resource "azurerm_virtual_network" "vnet" {
+  name                = "vnet-${var.resource_group_name}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  address_space       = [var.vnet_cidr]
+}
+
+resource "azurerm_subnet" "subnets" {
+  for_each             = var.subnet_prefixes
+  name                 = each.key
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [each.value]
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,0 +1,9 @@
+output "vnet_id" {
+  value       = azurerm_virtual_network.vnet.id
+  description = "The ID of the virtual network"
+}
+
+output "subnet_ids" {
+  value       = { for name, s in azurerm_subnet.subnets : name => s.id }
+  description = "A map of subnet names to their IDs"
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,0 +1,19 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for resources"
+}
+
+variable "vnet_cidr" {
+  type        = string
+  description = "Address space for the virtual network"
+}
+
+variable "subnet_prefixes" {
+  type        = map(string)
+  description = "Map of subnet names to CIDR prefixes"
+}


### PR DESCRIPTION
This PR delivers my two Infrastructure modules:

_**blob-backend**_

Provisioned Azure Resource Group cst8918-final-project-group-4

Created Storage Account abou0344tfstate & Blob Container tfstate for Terraform state

Disabled the remote‐backend block locally (backend.tf.disabled) to bootstrap without MFA issues

**_network_**

Created Terraform module that builds:

Virtual Network vnet-cst8918-final-project-group-4 (10.0.0.0/14)

Subnets for prod (10.0.0.0/16), test (10.1.0.0/16), dev (10.2.0.0/16), admin (10.3.0.0/16)

Also includes a .gitignore to exclude .terraform/ and local state files.